### PR TITLE
Feat: Link Button 컴포넌트 구현

### DIFF
--- a/src/link-button.html
+++ b/src/link-button.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="ko-KR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Apply Template</title>
+    <link rel="icon" href="/vite.svg" />
+    <link rel="preload" as="font" href="/font/woff2/PretendardVariable.woff2" crossorigin="anonymous" />
+    <link rel="stylesheet" as="style" href="/font/pretendardvariable.css" />
+    <link rel="stylesheet" href="/src/styles/components/link-button-component.css" />
+    <script type="module" src="/src/main.js"></script>
+  </head>
+  <body>
+    <a href="#" class="link-button-component">링크버튼</a>
+  </body>
+</html>

--- a/src/styles/components/link-button-component.css
+++ b/src/styles/components/link-button-component.css
@@ -1,0 +1,17 @@
+.link-button-component {
+  padding: 0.25rem;
+  color: var(--contents-content-primary);
+  border-bottom: 1px solid var(--contents-content-tertiary);
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.5;
+
+  &:hover {
+    border-bottom: 1px solid var(--contents-content-primary);
+  }
+
+  &:focus {
+    border: none;
+    outline: var(--accent) solid 2px;
+  }
+}


### PR DESCRIPTION
- link-button-component.css에 정의되어있음
- 사용시 a 태그의 class에 link-button-component를 넣어주면 됨

resolves #23

## PR 유형

- [x] 새로운 기능 추가

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
링크 버튼 컴포넌트를 추가했습니다.
[사용법]
사용하고자 하는 a태그의 class에 link-button-component를 추가하면 됩니다.
## 이슈

resolves #23
